### PR TITLE
Enable starting collection even if the height is too low

### DIFF
--- a/appng.js
+++ b/appng.js
@@ -71,6 +71,7 @@ if (fs.existsSync(batchinfofile)) {
    
    let blockchainresponse = request(options.method, options.baseUrl + options.uri, options.headers)
    let lastblockheight = parseInt(JSON.parse(blockchainresponse.body).height) 
+   paymentstopblock = lastblockheight - 1
 
    if (paymentstopblock > lastblockheight) {
 	let blocksleft = paymentstopblock - lastblockheight

--- a/appng.js
+++ b/appng.js
@@ -71,7 +71,10 @@ if (fs.existsSync(batchinfofile)) {
    
    let blockchainresponse = request(options.method, options.baseUrl + options.uri, options.headers)
    let lastblockheight = parseInt(JSON.parse(blockchainresponse.body).height) 
+   
+   if (paymentstopblock > lastblockheight)  {
    paymentstopblock = lastblockheight - 1
+   }
 
    if (paymentstopblock > lastblockheight) {
 	let blocksleft = paymentstopblock - lastblockheight


### PR DESCRIPTION
Will optimize the last scanned block to current height if it's bigger.